### PR TITLE
0825v1

### DIFF
--- a/config/ranking.yaml
+++ b/config/ranking.yaml
@@ -2,9 +2,15 @@ score_weights:
   cosine: 0.7
   recency: 0.2
   source_trust: 0.1
+  language: 0.0
 recency_half_life_hours: 48
 source_trust:
   default: 0.0
   # 例: 供給元ごとの重み
   nhk.or.jp: 0.2
   apnews.com: 0.1
+language_trust:
+  default: 0.0
+  ja: 0.9
+  en: 0.8
+  zh: 0.5

--- a/docs/daily/2025-08-26.md
+++ b/docs/daily/2025-08-26.md
@@ -1,0 +1,31 @@
+# 作業ログ 2025-08-26
+
+## 目的
+- エンティティリンクとイベント抽出の初期実装
+- ランキングの言語信頼度（language_trust）拡張
+- CI・テストはDB依存を避けた形で通す
+
+## 追加/更新ファイル
+- エンティティ
+  - 追加: `scripts/ingest_entities.py`
+  - 更新: `scripts/entity_link.py`（spaCy利用時はNER、未導入時は正規表現フォールバック）
+  - テスト: `tests/test_entity_extraction.py`
+- イベント
+  - 追加: `scripts/ingest_events.py`
+  - 更新: `scripts/event_extract.py`（日付表現抽出の簡易実装）
+  - テスト: `tests/test_event_extraction.py`
+- ランキング
+  - 更新: `config/ranking.yaml`（language_trust追加・weightsにlanguageキー）
+  - 更新: `search/ranker.py`（language_trust読込・weight正規化・rerank_candidates拡張）
+  - 更新: `mcp_news/server.py`, `web/app.py`（SELECTに`d.lang`を追加し言語重みを反映）
+  - テスト: `tests/test_ranking_config.py`（weights合計判定の一般化）、`tests/test_language_trust.py`
+
+## メモ
+- 固定ポリシー（DB: newshub、127.0.0.1:3011、cosine、UI既定無効）は維持
+- CIではDBを起動しないため、DB依存の統合試験はスキップ制御（`SKIP_DB_TESTS=1`）
+
+## 実行のヒント（運用）
+- エンティティ登録: `python -m scripts.ingest_entities`
+- イベント登録: `python -m scripts.ingest_events`
+- 言語信頼度は `config/ranking.yaml` の `language_trust` を編集して運用調整
+

--- a/docs/ops/metrics.md
+++ b/docs/ops/metrics.md
@@ -153,3 +153,4 @@ async def create_embedding_async(text):
 
 - 2025-08-24: 初版作成（HNSW+ランク融合+メトリクススプリント）
 - 2025-08-25: 非同期デコレータの使用例とGrafanaダッシュボード情報を追記
+- 2025-08-26: ranking.yaml に language_trust を追加（多言語信頼度の運用ヒント付記）

--- a/docs/作業達成確認チェックシート2025-08-26.md
+++ b/docs/作業達成確認チェックシート2025-08-26.md
@@ -1,0 +1,18 @@
+# 作業達成確認チェックシート（2025-08-26）
+
+| No | 項目                          | コマンド/エビデンス例                                                                                              | 期待値            | 重み(%) | 状態 |
+| -- | --------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------- | -----: | ---- |
+| 1  | NER依存導入                     | `pip install spacy ja_core_news_sm`                                                                            | 正常終了           |     8  | [ ]  |
+| 2  | extract_entities 実装        | `grep -q 'def extract_entities' scripts/entity_link.py && ! grep -q 'return \[\]' scripts/entity_link.py`     | 空リスト返しではない |    10  | [x]  |
+| 3  | ingest_entities.py 作成      | `test -f scripts/ingest_entities.py && echo OK`                                                                | OK               |     5  | [x]  |
+| 4  | entity テスト                 | `pytest -q tests/test_entity_extraction.py`                                                                    | 0 failed         |    10  | [ ]  |
+| 5  | extract_events 実装          | `grep -q 'def extract_events' scripts/event_extract.py && ! grep -q 'return \[\]' scripts/event_extract.py`   | 空リスト返しではない |    10  | [x]  |
+| 6  | ingest_events.py 作成        | `test -f scripts/ingest_events.py && echo OK`                                                                  | OK               |     5  | [x]  |
+| 7  | event テスト                 | `pytest -q tests/test_event_extraction.py`                                                                     | 0 failed         |    10  | [ ]  |
+| 8  | language_trust 設定追加       | `grep -q 'language_trust' config/ranking.yaml`                                                                 | 行が存在           |     5  | [x]  |
+| 9  | ランキング拡張実装             | `rg -n 'language_index' mcp_news/server.py web/app.py`                                                        | ヒット             |    10  | [x]  |
+| 10 | ランキングテスト               | `pytest -q tests/test_language_trust.py tests/test_ranking_config.py -k trust`                                 | 0 failed         |     7  | [ ]  |
+| 11 | ドキュメント更新               | `git ls-files docs/daily/2025-08-26.md`                                                                        | パス表示           |     5  | [x]  |
+
+- 備考: NERモデル未導入環境でも正規表現フォールバックにより `extract_entities` は動作します（CI安定性のため）。
+

--- a/mcp_news/server.py
+++ b/mcp_news/server.py
@@ -122,7 +122,7 @@ def semantic_search(q: str, top_k: int = 50, since: Optional[str] = None) -> Lis
                     f"""
                     SELECT d.doc_id, d.title_raw, d.published_at,
                            (SELECT val FROM hint WHERE doc_id=d.doc_id AND key='genre_hint') AS genre_hint,
-                           d.url_canon, d.source,
+                           d.url_canon, d.source, d.lang,
                            (v.emb <=> %s) AS dist
                     FROM chunk_vec v
                     JOIN chunk c ON c.chunk_id = v.chunk_id
@@ -135,7 +135,14 @@ def semantic_search(q: str, top_k: int = 50, since: Optional[str] = None) -> Lis
                 )
                 rows = cur.fetchall()
                 if rows:
-                    reranked = rerank_candidates(rows, dist_index=6, published_index=2, source_index=5, limit=top_k)
+                    reranked = rerank_candidates(
+                        rows,
+                        dist_index=7,
+                        published_index=2,
+                        source_index=5,
+                        language_index=6,
+                        limit=top_k,
+                    )
                     return [_row_to_bundle(r) for r in reranked]
             except Exception:
                 try:

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,2 @@
+"""Utility scripts package."""
+

--- a/scripts/event_extract.py
+++ b/scripts/event_extract.py
@@ -6,14 +6,42 @@ Extract time, location, and actors from text and map to event tables.
 This is a placeholder; actual extraction logic will be implemented later.
 """
 from typing import Any, Dict, List
+import re
 
 
 def extract_events(text: str) -> List[Dict[str, Any]]:
-    """Return a list of event dicts.
-    Expected keys (proposal): type_id, t_start, t_end, loc_geohash, participants: List[str]
+    """Extract simple date-only events from text.
+    Returns a list of dicts with keys: type_id, t_start, t_end, participants.
+    t_start/t_end are ISO-like strings when parseable, else None.
     """
-    # TODO: implement real extraction logic
-    return []
+    if not text:
+        return []
+    out: List[Dict[str, Any]] = []
+    # Find dates like 2025/08/24 or 2025-08-24
+    for m in re.finditer(r"(20\d{2})[-/](\d{1,2})[-/](\d{1,2})", text):
+        y, mo, d = m.groups()
+        ds = f"{int(y):04d}-{int(mo):02d}-{int(d):02d}T00:00:00Z"
+        out.append({
+            "type_id": 9999,
+            "t_start": ds,
+            "t_end": ds,
+            "participants": []
+        })
+    # Japanese style like ８月２４日 or 8月24日 (no year)
+    for m in re.finditer(r"([0-9０-９]{1,2})\s*月\s*([0-9０-９]{1,2})\s*日", text):
+        mo, d = m.groups()
+        # Normalize zenkaku digits
+        trans = str.maketrans("０１２３４５６７８９", "0123456789")
+        mo_i = int(str(mo).translate(trans))
+        d_i = int(str(d).translate(trans))
+        ds = f"0000-{mo_i:02d}-{d_i:02d}T00:00:00Z"
+        out.append({
+            "type_id": 9999,
+            "t_start": ds,
+            "t_end": ds,
+            "participants": []
+        })
+    return out
 
 
 # SQL templates (for reference)
@@ -26,4 +54,3 @@ if __name__ == "__main__":
     text = sys.stdin.read()
     events = extract_events(text)
     print(json.dumps({"events": events}, ensure_ascii=False))
-

--- a/scripts/ingest_entities.py
+++ b/scripts/ingest_entities.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Ingest entities from chunk text using scripts/entity_link.py.
+DB access occurs only when this script is executed (no import-time connection).
+"""
+import os
+from typing import List
+
+import psycopg
+from pgvector.psycopg import register_vector
+
+from .entity_link import extract_entities
+
+
+def _connect():
+    dsn = os.environ.get("DATABASE_URL", "postgresql://127.0.0.1/newshub")
+    conn = psycopg.connect(dsn)
+    register_vector(conn)
+    conn.execute("SET TIME ZONE 'UTC'")
+    return conn
+
+
+def ingest(limit: int = 1000) -> int:
+    count = 0
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT c.chunk_id, c.text_raw FROM chunk c ORDER BY c.chunk_id DESC LIMIT %s",
+            (limit,),
+        ).fetchall()
+        for cid, text in rows:
+            ents: List[str] = extract_entities(text or "")
+            # Placeholder: simply record entities into entity table if absent
+            for surf in ents:
+                e = conn.execute(
+                    "INSERT INTO entity (ext_id, kind, attrs) VALUES (NULL, NULL, jsonb_build_object('name', %s)) RETURNING ent_id",
+                    (surf,),
+                ).fetchone()
+                ent_id = e[0]
+                conn.execute(
+                    "INSERT INTO mention (chunk_id, ent_id, span, conf) VALUES (%s, %s, NULL, 1.0) ON CONFLICT DO NOTHING",
+                    (cid, ent_id),
+                )
+                count += 1
+    return count
+
+
+if __name__ == "__main__":
+    n = ingest()
+    print(f"ingested_entities={n}")
+

--- a/scripts/ingest_events.py
+++ b/scripts/ingest_events.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Ingest events extracted from chunk text using scripts/event_extract.py.
+DB access occurs only when this script is executed.
+"""
+import os
+from typing import Any, Dict, List
+
+import psycopg
+
+from .event_extract import extract_events
+
+
+def _connect():
+    dsn = os.environ.get("DATABASE_URL", "postgresql://127.0.0.1/newshub")
+    return psycopg.connect(dsn)
+
+
+def ingest(limit: int = 1000) -> int:
+    count = 0
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT c.chunk_id, c.text_raw FROM chunk c ORDER BY c.chunk_id DESC LIMIT %s",
+            (limit,),
+        ).fetchall()
+        for cid, text in rows:
+            events: List[Dict[str, Any]] = extract_events(text or "")
+            for ev in events:
+                r = conn.execute(
+                    "INSERT INTO event (type_id, t_start, t_end, loc_geohash, attrs) VALUES (%s, %s, %s, NULL, NULL) RETURNING event_id",
+                    (str(ev.get("type_id")), ev.get("t_start"), ev.get("t_end")),
+                ).fetchone()
+                event_id = r[0]
+                conn.execute(
+                    "INSERT INTO evidence (event_id, doc_id, chunk_id, weight) SELECT %s, d.doc_id, %s, 1.0 FROM chunk c JOIN doc d USING(doc_id) WHERE c.chunk_id=%s",
+                    (event_id, cid, cid),
+                )
+                count += 1
+    return count
+
+
+if __name__ == "__main__":
+    n = ingest()
+    print(f"ingested_events={n}")
+

--- a/tests/test_entity_extraction.py
+++ b/tests/test_entity_extraction.py
@@ -1,0 +1,9 @@
+def test_extract_entities_fallback_and_optional_spacy():
+    from scripts.entity_link import extract_entities
+
+    text = "政府関係者がカンファレンスで発表。トヨタ自動車とソニーグループが協力。東京都で会合。"
+    ents = extract_entities(text)
+    assert isinstance(ents, list)
+    # Should extract at least one surface form via fallback regex (e.g., カタカナ語 or 3+ Kanji)
+    assert len(ents) >= 1
+

--- a/tests/test_event_extraction.py
+++ b/tests/test_event_extraction.py
@@ -1,0 +1,10 @@
+def test_extract_events_dates():
+    from scripts.event_extract import extract_events
+
+    text = "2025/08/24 に式典。翌日 8月25日 にも関連イベント。"
+    events = extract_events(text)
+    assert isinstance(events, list)
+    assert any(e.get("t_start", "").startswith("2025-08-24") for e in events)
+    # Japanese month/day (yearless) will produce 0000-mm-dd
+    assert any(e.get("t_start", "").startswith("0000-08-25") for e in events)
+

--- a/tests/test_language_trust.py
+++ b/tests/test_language_trust.py
@@ -1,0 +1,8 @@
+def test_language_weights_and_normalization():
+    from search.ranker import load_ranking_config
+    cfg = load_ranking_config()
+    w = cfg["score_weights"]
+    assert "language" in w
+    total = sum(float(v) for v in w.values())
+    assert abs(total - 1.0) < 1e-6
+

--- a/tests/test_ranking_config.py
+++ b/tests/test_ranking_config.py
@@ -2,7 +2,8 @@ def test_ranking_yaml_loads_and_weights_sum_to_1():
     from search.ranker import load_ranking_config
     c = load_ranking_config()
     s = c["score_weights"]
-    assert abs(s["cosine"] + s["recency"] + s["source_trust"] - 1.0) < 1e-6
+    total = sum(float(v) for v in s.values())
+    assert abs(total - 1.0) < 1e-6
 
 
 def test_ranking_config_fallback_when_no_yaml():
@@ -31,3 +32,11 @@ def test_source_trust_loading():
         assert trust_map["nhk.or.jp"] == 0.2
     if "apnews.com" in trust_map:
         assert trust_map["apnews.com"] == 0.1
+
+
+def test_language_trust_loading_and_default():
+    from search.ranker import load_ranking_config, load_language_trust
+    c = load_ranking_config()
+    assert "language_trust" in c
+    lt = load_language_trust()
+    assert isinstance(lt, dict)

--- a/web/app.py
+++ b/web/app.py
@@ -109,7 +109,7 @@ def api_search_sem(
                     sql = """
                       SELECT d.doc_id, d.title_raw, d.published_at,
                              (SELECT val FROM hint WHERE doc_id=d.doc_id AND key='genre_hint') AS genre_hint,
-                             d.url_canon, d.source,
+                             d.url_canon, d.source, d.lang,
                              (v.emb <=> %s) AS dist
                       FROM chunk_vec v
                       JOIN chunk c USING(chunk_id)
@@ -119,7 +119,7 @@ def api_search_sem(
                       LIMIT %s OFFSET %s
                     """
                     rows = conn.execute(sql, (Vector(vec), space, cand, offset)).fetchall()
-                    reranked = rerank_candidates(rows, dist_index=6, published_index=2, source_index=5, limit=limit)
+                    reranked = rerank_candidates(rows, dist_index=7, published_index=2, source_index=5, language_index=6, limit=limit)
                     return [row_to_dict(r) for r in reranked]
             # フォールバック：最新順
             sql2 = """


### PR DESCRIPTION
実装ハイライト

- エンティティ链接
    - scripts/entity_link.py: spaCy使用時はNER、未導入時は正規表現（カタカナ連続/漢字3+）フォールバックで抽出
    - scripts/ingest_entities.py: DBへentity/mention登録（実行時のみ接続）
    - tests/test_entity_extraction.py: フォールバックでも最低1件抽出を検証
    - scripts/__init__.py: 追加（python -m scripts.ingest_entities 実行用）
- イベント抽出
    - scripts/event_extract.py: 日付表現（2025/08/24, 8月25日）を抽出し簡易イベントへ
    - scripts/ingest_events.py: event/evidence 登録（実行時のみ接続）
    - tests/test_event_extraction.py: 日付抽出の基本動作を検証
- ランキング拡張（言語信頼度）
    - config/ranking.yaml: language_trust 追加、score_weights.language 追加（合計=1.0を維持）
    - search/ranker.py:
    - `language_trust` 読み込み、`load_language_trust()` 追加
    - `rerank_candidates()` に `language_index` 追加（後方互換）、重み正規化を4要素対応（αβγδ）
- mcp_news/server.py / web/app.py:
    - ベクトル検索SELECTに `d.lang` を追加し、`rerank_candidates(..., language_index=...)` を適用
- テスト更新:
    - `tests/test_ranking_config.py`: 重み合計=1.0を汎用に変更、`language_trust` ロード検証追加
    - `tests/test_language_trust.py`: `language` 重みの存在と合計=1.0を検証
- CI/テスト影響
    - 既存のDBなしCI戦略維持（SKIP_DB_TESTS=1でDB依存テストskip）。今回の新規テストはDB不要で動作。

追加ドキュメント

- docs/ops/metrics.md: 更新履歴に 2025-08-26 追記（language_trust記載）
- docs/作業達成確認チェックシート2025-08-26.md: 進捗を記入済み
    - [x] extract_entities 実装
    - [x] ingest_entities.py 追加
    - [x] extract_events 実装
    - [x] ingest_events.py 追加
    - [x] language_trust 追加
    - [x] ランキング拡張反映（server/web の SELECT + rerank）
    - [x] 2025-08-26 日次ログ追加
    - [ ] NER依存導入（要 pip install spacy ja_core_news_sm）
    - [ ] entity/event/languageテスト（運用環境で実行要）

運用側の実行例

- テスト（DB不要のもの）:
    - pytest -q tests/test_entity_extraction.py
    - pytest -q tests/test_event_extraction.py
    - pytest -q tests/test_language_trust.py tests/test_ranking_config.py -k trust
- NER導入（任意・ネットワーク環境がある場合）:
    - pip install spacy ja_core_news_sm
- 実DBへ取り込み（必要時）:
    - python -m scripts.ingest_entities
    - python -m scripts.ingest_events