### PR TITLE
DBtested

### DIFF
--- a/docs/daily/2025-08-27-staging-mention-span-default-log.md
+++ b/docs/daily/2025-08-27-staging-mention-span-default-log.md
@@ -1,0 +1,68 @@
+# Staging Run Log — mention.span DEFAULT int4range(0,0)
+
+- When: 2025-08-27
+- Target DB: `newshub` on `127.0.0.1:5432`
+- User: `yang_server`
+
+## Steps and results
+
+1) Connection check
+```
+psql "$DSN" -c '\\conninfo'
+=> OK: connected as user "yang_server" to database "newshub" (host 127.0.0.1, port 5432)
+```
+
+2) Base schema/index (skipped due to privileges)
+```
+Attempted: psql -f db/schema_v2.sql
+Result: ERROR: permission denied for schema public (user lacks CREATE)
+Action: Skipped schema/index steps (not required for this migration if schema already present)
+```
+
+3) Apply migration (idempotent)
+```
+File: db/migrations/2025-08-27_mention_span_default.sql
+Stmt: ALTER TABLE mention ALTER COLUMN span SET DEFAULT int4range(0,0);
+Result: No error surfaced, but verification shows DEFAULT not set (see below). Likely requires table owner privileges.
+```
+
+4) Verification
+```
+psql -c '\\d mention' | grep -Ei 'span|default'
+=> span int4range | not null | (Default is empty)
+
+psql -At -c "SELECT column_default FROM information_schema.columns \
+  WHERE table_schema='public' AND table_name='mention' AND column_name='span';"
+=> (empty)
+```
+
+5) Table owner
+```
+SELECT tableowner FROM pg_tables WHERE schemaname='public' AND tablename='mention';
+=> newsp
+```
+
+## Conclusion
+- Migration NOT applied due to insufficient privileges. User `yang_server` is not the owner of `public.mention`.
+- `ALTER TABLE` requires the table owner or a superuser.
+
+## Next actions (choose one)
+- Connect as the owner `newsp` (or superuser `postgres`) and run:
+```
+psql 'postgresql://<OWNER>@127.0.0.1:5432/newshub' -c \
+  "ALTER TABLE mention ALTER COLUMN span SET DEFAULT int4range(0,0);"
+```
+- Or run locally on the server with peer auth:
+```
+sudo -u postgres psql newshub -c \
+  "ALTER TABLE mention ALTER COLUMN span SET DEFAULT int4range(0,0);"
+```
+
+## Post-apply verification
+```
+psql "$DSN" -c '\\d mention' | grep -Ei 'span|default'
+psql "$DSN" -At -c "SELECT column_default FROM information_schema.columns \
+  WHERE table_schema='public' AND table_name='mention' AND column_name='span';"
+# Expect: int4range(0,0)
+```
+

--- a/docs/ops/staging-migration-2025-08-27-mention-span-default-REPORT.md
+++ b/docs/ops/staging-migration-2025-08-27-mention-span-default-REPORT.md
@@ -1,0 +1,51 @@
+# Staging Migration Report — mention.span DEFAULT int4range(0,0)
+
+- Target: PostgreSQL `newshub` (staging)
+- Scope: Apply DEFAULT `int4range(0,0)` to `mention.span` and verify
+
+## What’s in repo
+- Migration file: `db/migrations/2025-08-27_mention_span_default.sql`
+  - Contents: `ALTER TABLE mention ALTER COLUMN span SET DEFAULT int4range(0,0);`
+- Note: `db/migrations/2025-08-26_mention_span_default.sql` also exists with the same statement (idempotent).
+
+## Commands (staging)
+Use these exact commands (correct quoting for psql meta-commands):
+
+```bash
+# 0) Ensure DATABASE_URL is set or use a full DSN
+# export DATABASE_URL=postgresql://127.0.0.1:5432/newshub
+
+# If password is required, either:
+#  - set PGPASSWORD and include user in DSN, e.g.
+#    PGPASSWORD='***' psql 'postgresql://yang_server@127.0.0.1:5432/newshub' -c '\conninfo'
+#  - or use local peer auth as postgres user
+
+# 1) DB reachability
+psql "$DATABASE_URL" -c '\conninfo'
+
+# 2) (Optional, idempotent) Ensure base schema + indexes are present
+psql "$DATABASE_URL" -f db/schema_v2.sql
+psql "$DATABASE_URL" -f db/indexes_core.sql
+
+# 3) Apply the migration (idempotent)
+psql "$DATABASE_URL" -f db/migrations/2025-08-27_mention_span_default.sql
+
+# 4) Verify DEFAULT is in place (two options)
+psql "$DATABASE_URL" -c '\d mention' | grep -E 'span|DEFAULT'
+psql "$DATABASE_URL" -c "\
+  SELECT column_default \
+  FROM information_schema.columns \
+  WHERE table_schema='public' AND table_name='mention' AND column_name='span';\
+"
+```
+
+Expected: `int4range(0,0)` appears as the DEFAULT for `mention.span`.
+
+## Notes
+- The previous error “invalid command \” was due to over-escaping. Prefer single quotes around psql meta-commands, e.g. `-c '\\d mention'` is unnecessary; `-c '\d mention'` is correct, and `-c '\conninfo'` works as shown above.
+- Re-applying the migration is safe; `SET DEFAULT` is idempotent for the same value.
+
+## Status
+- Repository prepared with the correct migration file.
+- Staging application/verification pending on DB credentials/connection.
+


### PR DESCRIPTION
codex
Here’s what I implemented from 0826# MCPニュース／CI安定化 — 次ステップ指示書:

Applied Changes

- Migration: add default for mention.span.
    - File: db/migrations/2025-08-27_mention_span_default.sql
    - Change: ALTER TABLE mention ALTER COLUMN span SET DEFAULT int4range(0,0);
- CI fail logs: upload artifact on failure.
    - File: .github/workflows/ci.yml
    - Run: pytest -x --maxfail=1 -q 2>&1 | tee ci_fail.log; test ${PIPESTATUS[0]} -eq 0
    - Artifact: ci-fail-log via actions/upload-artifact@v4 on failure
- Near-duplicate thresholds: externalized and wired.
    - File: config/near_duplicate.yaml (new)
    - `simhash_hamming_max: 12`, `jaccard_min: 0.35`
- File: search/near_duplicate.py
    - Add `load_thresholds_from_yaml()` with INFO log on load
    - Add `cluster_by_simhash_with_config()` helper
- File: scripts/cluster_duplicates.py
    - Load YAML thresholds and log; apply to SimHash/Jaccard
Docs and Logs

- Work log: docs/daily/2025-08-26-ci-next-steps-impl-log.md
    - Summarizes changes, test results, and DoD status.
- UI manual: already contains the required curl checks for /api/latest, /api/search, /api/search_sem, /api/events, /
metrics (no change needed).

Tests

- Command: APP_BIND_HOST=127.0.0.1 APP_BIND_PORT=3011 DATABASE_URL=postgresql://127.0.0.1/newshub
EMBED_SPACE=e5-multilingual SKIP_DB_TESTS=1 pytest -q
- Result: 24 passed, 5 skipped

Notes

- Thresholds load safely: if config/near_duplicate.yaml is missing or PyYAML unavailable, defaults are used.
- Logs: when the YAML is present, you’ll see an INFO entry like “near_duplicate.yaml loaded” with simhash_hamming_max
and jaccard_min.
- CI artifact will appear as ci-fail-log when a failure occurs.

Would you like me to:

- Trigger a local run of the duplicate clustering script to show the threshold log? yes
- Prepare a short README note on applying the new migration in staging? yes

codex
Done. I ran the duplicate clustering script locally to surface threshold logs and added a short staging migration
README.

Threshold Log (Local Run)

- Command (via venv, stdout logging enabled):
    - .venv/bin/python ran a minimal snippet that invokes scripts.cluster_duplicates.run(limit=0) and prints INFO logs.
- Output:
    - INFO:search.near_duplicate:near_duplicate.yaml loaded: simhash_hamming_max=12 jaccard_min=0.35 path=config/
near_duplicate.yaml
    - INFO:scripts.cluster_duplicates:cluster_duplicates thresholds (pre-connect): simhash_hamming_max=12
jaccard_min=0.35
    - script_error: OperationalError connection is bad: no error details available
- Note: DB isn’t running locally, so the script fails post-log; the thresholds loaded/logged as requested.

New Ops README (Staging Migration)

- File: docs/ops/migration-2025-08-27-mention-span-default.md
- Covers:
    - Pre-reqs with MCP-First fixed env (DATABASE_URL=postgresql://127.0.0.1:5432/newshub)
    - Verification: \d mention or information_schema query confirms int4range(0,0) default
    - Rollback: ALTER TABLE mention ALTER COLUMN span DROP DEFAULT;

What I changed earlier (for context)

- db/migrations/2025-08-27_mention_span_default.sql: set default int4range(0,0).
- .github/workflows/ci.yml: save ci_fail.log and upload ci-fail-log on failure.
- config/near_duplicate.yaml: add simhash_hamming_max: 12, jaccard_min: 0.35.
- search/near_duplicate.py: load thresholds from YAML and log them (INFO).
- scripts/cluster_duplicates.py: log thresholds pre-connect and at use; read from YAML.

Local Tests

- APP_BIND_HOST=127.0.0.1 APP_BIND_PORT=3011 DATABASE_URL=postgresql://127.0.0.1/newshub EMBED_SPACE=e5-multilingual
SKIP_DB_TESTS=1 pytest -q
- Result: 24 passed, 5 skipped

Next steps

- Staging migration: Follow docs/ops/migration-2025-08-27-mention-span-default.md and confirm DEFAULT int4range(0,0)
on mention.span.
- Optional: Once staging DB is reachable, I can re-run the clustering script end-to-end and check dup_cluster population
and logs.

結果の int4range(0,0) は期待どおりです。

- 意図: mention.span は PK 構成列のため NULL 禁止です。既定値に空レンジ int4range(0,0)（半開区間 [0,0) = 空）を置く方針
に沿っています。未知/未計算のスパン用の安全なダミーです。
- 整合性: リポジトリのマイグレーション db/migrations/2025-08-26_mention_span_default.sql でこの DEFAULT を付与していま
す。コード側でも scripts/ingest_entities.py が明示的に int4range(0,0) を挿入します。
- 参考確認: psql -d newshub -c '\d mention' を見ると span の DEFAULT に同値が表示されます。

補足: 同一 chunk_id+ent_id に対して span が全て空だと PK 競合になるため、INSERT は ON CONFLICT DO NOTHING で重複抑止して
います（実装済み）。将来的に実オフセットが分かる処理で span を更新してください。