### PR TITLE
T5

### DIFF
--- a/docs/T5指示書チェックシード.md
+++ b/docs/T5指示書チェックシード.md
@@ -1,0 +1,161 @@
+T5（再ランク＋新鮮度フォールバック目視セット）の指示書／チェックシードをまとめます。
+
+---
+
+# MCPニュース — T5: 再ランク＋新鮮度フォールバック（CodexCLI用）
+
+作成: 2025-08-27 JST
+対象: `yangnana7/newspaper`（master）
+前提: T4 完了（`chunk_vec` 欠損0、HNSW稼働）
+
+## 0) 目的とDoD
+
+- ランク融合（cosine/新鮮度/ソース信頼/言語）の重みが設定可能で反映されている。
+- `/api/search_sem` が以下を満たす：
+  - `q` が未指定（または不正）でも最新順でフォールバックして応答する。
+  - `q` が指定されると、ベクトル近傍→再ランクで応答（上位N件の順位に一貫性）。
+- 再ランクにおいて、同一ソース・同等距離の2件なら「新しい方」が上位に来る（半減期の効果）。
+- MCP-First継続（`/metrics`=HELP、`/`=404）。
+
+---
+
+## 1) コンフィグの所在と反映
+
+- ランク融合の定義は `config/ranking.yaml`（既定）＋ `config/ranking.toml`（簡易上書き）で制御します。
+  - YAML 既定値（例）
+    ```yaml
+    score_weights:
+      cosine: 0.7
+      recency: 0.2
+      source_trust: 0.1
+      language: 0.0
+    recency_half_life_hours: 48
+    source_trust:
+      default: 0.0
+      nhk.or.jp: 0.2
+      apnews.com: 0.1
+    language_trust:
+      default: 0.0
+      ja: 0.9
+      en: 0.8
+    ```
+  - TOML 簡易上書き（存在すれば優先）
+    ```toml
+    alpha = 0.7   # cosine weight
+    beta  = 0.2   # recency weight
+    gamma = 0.1   # source_trust weight
+    half_life_hours = 48
+    ```
+  - さらに環境変数で最終上書き可能：`RANK_ALPHA/RANK_BETA/RANK_GAMMA/RECENCY_HALFLIFE_HOURS`。
+
+反映コード:
+- `search/ranker.py` の `load_ranking_config()`／`load_rank_fusion_overrides()`／`rerank_candidates()` を参照。
+- `web/app.py` と `mcp_news/server.py` は `rerank_candidates()` を使って候補を再ランク。
+
+---
+
+## 2) API動作確認（フォールバックと再ランクの目視）
+
+準備（固定値遵守）:
+```bash
+export APP_BIND_HOST=127.0.0.1 APP_BIND_PORT=3011
+export DATABASE_URL='postgresql://newsp@127.0.0.1:5432/newshub'
+export PGPASSWORD='＜newspのパスワード＞'
+```
+
+2.1 `q` 未指定（新着順フォールバック）
+```bash
+curl -s "http://127.0.0.1:3011/api/search_sem?limit=5" | jq -r '.[].published_at'
+# 期待：JSTで降順（新しいほど先頭）。
+```
+
+2.2 `q` 指定（ベクトル近傍→再ランク）
+```bash
+# 例: 3次元のダミーベクトルでもHTTPは200で応答し、
+#     取得候補を再ランクして limit 件を返却（DB内容により空配列/短配列の場合あり）。
+curl -s --get "http://127.0.0.1:3011/api/search_sem" \
+  --data-urlencode "limit=5" \
+  --data-urlencode 'q=[0.0,0.0,0.0]' | jq length
+```
+
+---
+
+## 3) 再ランクの新鮮度優先が効くこと（簡易検証）
+
+`pytest`（ローカルDB不要の論理テスト）:
+```bash
+pytest -q -k "ranking_toml_overrides_and_recency_monotonic"
+# 期待：PASS（同距離・同一ソースの2件で、新しい方が先頭）
+```
+
+加えて、ファイル読み込みの検証:
+```bash
+pytest -q -k "ranking_yaml_loads_and_weights_sum_to_1 and ranking_config_fallback_when_no_yaml and source_trust_loading and language_trust_loading_and_default"
+```
+
+---
+
+## 4) 重みの即時変更（目視用）
+
+一時的に環境変数で強制上書き（プロセス単位）:
+```bash
+export RANK_ALPHA=0.5 RANK_BETA=0.4 RANK_GAMMA=0.1 RECENCY_HALFLIFE_HOURS=24
+curl -s "http://127.0.0.1:3011/api/search_sem?limit=5" | jq -r '.[].published_at'
+# 新鮮度重視（BETA↑）で、最近記事がより上位に来る傾向を目視。
+```
+
+恒久設定は `config/ranking.yaml`／`config/ranking.toml` を編集（再起動）
+```bash
+# 例: ranking.toml を好みの係数に修正
+sed -i 's/^beta\s*=.*/beta = 0.35/' config/ranking.toml
+# Uvicorn/systemd を再起動後、同一クエリで上位変動を目視
+```
+
+---
+
+## 5) MCP-Firstの確認（回帰）
+
+```bash
+curl -si http://127.0.0.1:3011/ | head -n1      # 期待：HTTP/1.1 404
+curl -s  http://127.0.0.1:3011/metrics | head    # 期待：# HELP ...
+```
+
+---
+
+## 6) DoDチェックシード（記入）
+
+- [ ] `/api/search_sem`：`q` 未指定でも200で新着順フォールバック
+- [ ] `/api/search_sem`：`q` 指定で候補→再ランク→上位N件返却
+- [ ] 再ランク：同距離・同一ソースなら新しい方が上位
+- [ ] ランク重み：`ranking.yaml/toml` や `RANK_*` 変更が反映
+- [ ] MCP-First継続（`/metrics`=HELP, `/`=404）
+
+---
+
+## 7) トラブルシュート
+
+- 200だが空配列：DBに一致候補が少ない／`embedding_space` 不一致。T4の欠損0と同一spaceを確認。
+- `q` が不正JSON：サーバ側で新着順にフォールバックする仕様。ログに注意。
+- 再ランクが利かない：環境変数で `RANK_*` を明示設定し、`ranking.toml`/`yaml` の競合を排除して再試験。
+- UIが出る：`UI_ENABLED=0` を確認。Nginx層では `/` と `/static/` を拒否。
+
+---
+
+以上。実施ログは `docs/ops/T5-impl-log-2025-08-27.md` に貼ってクローズしてください。
+
+---
+
+## 実施結果（CodexCLI）
+
+本環境（サンドボックス）では `pytest`/`curl` の実行が制限されるため、以下は静的検証ベースの結果です。実機でのAPI応答・EXPLAINの最終確認をお願いします。
+
+- [x] ランク融合ロジックの存在と反映経路（`search/ranker.py`、`config/ranking.yaml/.toml`、`RANK_*`）を静的確認済み
+- [x] `/api/search_sem` のフォールバック実装（`q` 不在/不正→新着順）を静的確認済み
+- [x] MCP-First 継続（`/`=404、`/metrics`=# HELP）コード上確認済み
+- [ ] `/api/search_sem`：`q` 未指定フォールバック=200を実機で目視
+- [ ] `/api/search_sem`：`q` 指定で候補→再ランク→上位N件返却を実機で目視
+- [ ] 再ランク：同距離・同一ソースで新しい方が上位（`tests/test_rank_fusion.py` のシナリオと一致）を実機で目視
+
+参考:
+- 実機確認コマンドは本文「2) API動作確認」「3) 再ランクの新鮮度優先」を参照。
+- 実施ログは `docs/ops/T5-impl-log-2025-08-27.md` に記入済み（要実機項目はペンディングで明示）。

--- a/docs/ops/T5-impl-log-2025-08-27.md
+++ b/docs/ops/T5-impl-log-2025-08-27.md
@@ -1,0 +1,46 @@
+MCPニュース — T5 実施ログ（再ランク＋新鮮度フォールバック）
+
+日時: 2025-08-27 JST
+担当: Codex CLI
+対象: yangnana7/newspaper（ローカル作業）
+
+実施内容:
+- ドキュメント `docs/T5指示書チェックシード.md` を追加（DoD・手順・トラブルシュート）。
+- 既存コードの再ランク機構（search/ranker.py）とAPIのフォールバック動作を確認。
+
+サンドボックス検証（実行制限下の静的確認）:
+- 再ランク実装: `search/ranker.py` の `rerank_candidates` にて cosine/recency/source_trust/language を重み合成、降順ソートで上位N抽出を確認。
+- 設定反映: `config/ranking.yaml` と `config/ranking.toml` の両方が存在し、環境変数 `RANK_*` で最終上書きされることを確認。
+- フォールバック: `web/app.py` の `/api/search_sem` は `q` 不在/不正時に最新順クエリへフォールバックし200で配列を返す実装を確認。
+- MCP-First: `web/app.py` の `/` は `UI_ENABLED` 未設定時に 404。`/metrics` は Prometheus 形式文字列を返す実装を確認。
+
+注: 本環境では seccomp 制限により `pytest` や `curl` 実行が拒否されるため、動作テストはホスト側での実施をお願いします（下記メモ）。
+
+実行メモ（作業者記入欄）:
+1) 環境セット
+   export APP_BIND_HOST=127.0.0.1 APP_BIND_PORT=3011
+   export DATABASE_URL='postgresql://newsp@127.0.0.1:5432/newshub'
+   export PGPASSWORD='＜newspのパスワード＞'
+
+2) フォールバック確認
+   curl -s "http://127.0.0.1:3011/api/search_sem?limit=5" | jq -r '.[].published_at'
+
+3) 再ランク確認
+   curl -s --get "http://127.0.0.1:3011/api/search_sem" --data-urlencode "limit=5" --data-urlencode 'q=[0,0,0]' | jq length
+
+4) 重み変更の即時上書き（任意）
+   export RANK_ALPHA=0.5 RANK_BETA=0.4 RANK_GAMMA=0.1 RECENCY_HALFLIFE_HOURS=24
+
+5) MCP-First 確認
+   curl -si http://127.0.0.1:3011/ | head -n1
+   curl -s  http://127.0.0.1:3011/metrics | head
+
+DoDチェック（結果記入）:
+- [ ] `/api/search_sem`：`q` 未指定フォールバック=OK（要実機目視）
+- [ ] `/api/search_sem`：`q` 指定で再ランク=OK（要実機目視）
+- [ ] 新鮮度優先が効く=OK（要実機目視）
+- [ ] 重み変更が反映=OK（要実機目視）
+- [x] MCP-First継続=OK（静的確認）
+
+備考:
+- テスト補助は `tests/test_rank_fusion.py` にあり（DB不要の論理テスト含む）。


### PR DESCRIPTION
codex
完了しました。T5の指示書と実施ログに記入しました。

更新ファイル

- docs/T5指示書チェックシード.md
    - 手順・DoDのままに「実施結果（CodexCLI）」節を追記。
    - 静的確認でOKな項目をチェック、実機確認が必要な項目は未チェックで明示。
- docs/ops/T5-impl-log-2025-08-27.md
    - サンドボックス下の静的確認内容を追記。
    - DoDチェック欄を記入（MCP-Firstはチェック済み、他は「要実機目視」）。


- ランク融合ロジックと設定反映経路: OK
- /api/search_sem のフォールバック実装: OK
- MCP-First継続（/=404, /metrics=# HELP）: OK
- 実API応答の目視と再ランクの動作は、ホスト実行での確認が必要

実機での仕上げ（DoD埋め用）

- 環境
    - export APP_BIND_HOST=127.0.0.1 APP_BIND_PORT=3011
    - export DATABASE_URL='postgresql://newsp@127.0.0.1:5432/newshub'
    - export PGPASSWORD='＜newspのパスワード＞'
- フォールバック確認
    - curl -s "http://127.0.0.1:3011/api/search_sem?limit=5" | jq -r '.[].published_at'
- 再ランク確認
    - curl -s --get "http://127.0.0.1:3011/api/search_sem" --data-urlencode "limit=5" --data-urlencode 'q=[0,0,0]' |
jq length
- 重みの即時上書き（任意）
    - export RANK_ALPHA=0.5 RANK_BETA=0.4 RANK_GAMMA=0.1 RECENCY_HALFLIFE_HOURS=24
- MCP-First
    - curl -si http://127.0.0.1:3011/ | head -n1 → 404
    - curl -s  http://127.0.0.1:3011/metrics | head → # HELP

このまま実機で上記を実行いただければ、docs/ops/T5-impl-log-2025-08-27.md のチェック欄をすべて埋められます。必要なら、こ
ちらでコマンド実行とDoDチェック埋めまで代行します（DB接続情報の承認または .pgpass 設定をご提示ください）。